### PR TITLE
Add QuestaSim as a simulator option and add ASIC register file

### DIFF
--- a/rtl/vproc_core.sv
+++ b/rtl/vproc_core.sv
@@ -799,8 +799,8 @@ module vproc_core #(
             logic [VPORT_CNT[i]:0][4       :0] vreg_rd_addr;
             logic [VPORT_CNT[i]:0][VREG_W-1:0] vreg_rd_data;
             always_comb begin
+                vregfile_rd_addr[VPORT_OFFSET[i]+VPORT_CNT[i]-1:VPORT_OFFSET[i]] = vreg_rd_addr    [VPORT_CNT[i]:0];
                 for (int j = 0; j < VPORT_CNT[i]; j++) begin
-                    vregfile_rd_addr[VPORT_OFFSET[i] + j] = vreg_rd_addr    [                  j];
                     vreg_rd_data    [                  j] = vregfile_rd_data[VPORT_OFFSET[i] + j];
                 end
                 vreg_rd_data[VPORT_CNT[i]] = vreg_mask;

--- a/rtl/vproc_core.sv
+++ b/rtl/vproc_core.sv
@@ -799,9 +799,9 @@ module vproc_core #(
             logic [VPORT_CNT[i]:0][4       :0] vreg_rd_addr;
             logic [VPORT_CNT[i]:0][VREG_W-1:0] vreg_rd_data;
             always_comb begin
-                vregfile_rd_addr[VPORT_OFFSET[i]+VPORT_CNT[i]-1:VPORT_OFFSET[i]] = vreg_rd_addr    [VPORT_CNT[i]:0];
+                vregfile_rd_addr[VPORT_OFFSET[i]+VPORT_CNT[i]-1:VPORT_OFFSET[i]] = vreg_rd_addr[VPORT_CNT[i]-1:0];
                 for (int j = 0; j < VPORT_CNT[i]; j++) begin
-                    vreg_rd_data    [                  j] = vregfile_rd_data[VPORT_OFFSET[i] + j];
+                    vreg_rd_data[j] = vregfile_rd_data[VPORT_OFFSET[i] + j];
                 end
                 vreg_rd_data[VPORT_CNT[i]] = vreg_mask;
             end

--- a/rtl/vproc_pkg.sv
+++ b/rtl/vproc_pkg.sv
@@ -9,13 +9,14 @@ package vproc_pkg;
 //`define VPROC_OP_REGS_UNION
 
 typedef enum {
-    RAM_GENERIC,
-    RAM_XLNX_RAM32M
+    RAM_GENERIC     = 0,
+    RAM_XLNX_RAM32M = 1,
+    RAM_ASIC        = 2
 } ram_type;
 
 typedef enum {
-    MUL_GENERIC,
-    MUL_XLNX_DSP48E1
+    MUL_GENERIC      = 0,
+    MUL_XLNX_DSP48E1 = 1
 } mul_type;
 
 typedef enum logic [1:0] {

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -14,6 +14,10 @@ SIM_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 # Vivado TCL script
 VIVADO_TCL := $(addprefix $(SIM_DIR),sim_vivado.tcl)
 
+# Questa TCL script and variable
+QUESTA_TCL := $(addprefix $(SIM_DIR),sim_questa.tcl)
+VSIM       ?= vsim
+
 # project directory
 PROJ_DIR_TMP := $(shell mktemp -d)
 PROJ_DIR     ?= $(PROJ_DIR_TMP)
@@ -39,7 +43,7 @@ VSLD_W ?= $(if $(filter-out 32,$(VMUL_W)),$(VMUL_W),64)
 ICACHE_SZ     ?= 0
 ICACHE_LINE_W ?= 128
 DCACHE_SZ     ?= 0
-DCACHE_LINE_W ?= $$(($(VMEM_W) * 2))
+DCACHE_LINE_W ?= $(shell echo $$(( $(VMEM_W) * 2 )))
 
 # select memory width (bits), size (bytes), and latency (cycles, 1 is minimum)
 MEM_W		?= 32
@@ -111,3 +115,10 @@ verilator:
 	$(PROJ_DIR)/obj_dir/Vvproc_top $(abspath $(PROG_PATHS_LIST)) $(MEM_W)     \
 	    $(MEM_SZ) $(MEM_LATENCY) $$(($(VREG_W) * 2)) $(abspath $(TRACE_FILE)) \
 	    $(abspath $(TRACE_VCD)) $(abspath $(TRACE_FST))
+
+questa:
+	cd $(PROJ_DIR) && $(VSIM) -batch -do 'do $(QUESTA_TCL)                    \
+	    $(SIM_DIR).. $(CORE_DIR) "$(VREG_W) $(VMEM_W) $(VMUL_W) $(VALU_W)     \
+	    $(VSLD_W) $(ICACHE_SZ) $(ICACHE_LINE_W) $(DCACHE_SZ) $(DCACHE_LINE_W) \
+	    $(MEM_W) $(MEM_SZ) $(MEM_LATENCY)" $(abspath $(TRACE_FILE))           \
+	    $(abspath $(PROG_PATHS_LIST)) "$(TRACE_SIGS)"'

--- a/sim/sim_questa.tcl
+++ b/sim/sim_questa.tcl
@@ -1,0 +1,118 @@
+# Copyright 2022 CSEM
+#
+# This file, and derivatives thereof are licensed under the
+# Solderpad License, Version 2.0 (the "License");
+# Use of this file means you agree to the terms and conditions
+# of the license and are in full compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://solderpad.org/licenses/SHL-2.0/
+#
+# Unless required by applicable law or agreed to in writing, software
+# and hardware implementations thereof
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+if {$argc < 5} {
+    puts "usage: sim.tcl VPROC_DIR CORE_DIR PARAMS LOG_FILE PROG_PATHS_LIST \[SYMBOLS ...\]"
+    exit 2
+}
+
+# get command line arguments
+set vproc_dir $1
+set core_dir $2
+set params_var $3
+set log_file_path $4
+set prog_paths_var $5
+set log_signals $6
+
+# default values for dv_utils and prim
+set dv_utils ""
+set prim ""
+
+lassign $params_var VREG_W VMEM_W VMUL_W VALU_W VSLD_W ICACHE_SZ ICACHE_LINE_W DCACHE_SZ DCACHE_LINE_W MEM_W MEM_SZ MEM_LATENCY
+
+# RAM_TYPE=2 is translated to vproc_pkg::RAM_ASIC
+set RAM_TYPE "2"
+# MUL_TYPE=0 is translated to vproc_pkg::MUL_GENERIC
+set MUL_TYPE "0"
+
+# create source file list
+lappend src_list "$vproc_dir/rtl/vproc_pkg.sv"
+lappend src_list "$vproc_dir/sim/vproc_tb.sv"
+set main_core ""
+if {[string first "ibex" $core_dir] != -1} {
+    set main_core "MAIN_CORE_IBEX"
+    lappend src_list "$core_dir/rtl/ibex_pkg.sv"
+    lappend src_list "$core_dir/rtl/ibex_tracer_pkg.sv"
+    lappend src_list "$core_dir/vendor/lowrisc_ip/ip/prim/rtl/prim_ram_1p_pkg.sv"
+    foreach file [glob -type f $core_dir\/*rtl\/*\[a-z,_\]*.sv] {
+        lappend src_list $file
+    }
+    lappend src_list "$core_dir/syn/rtl/prim_clock_gating.v"
+    set dv_utils "$core_dir/vendor/lowrisc_ip/dv/sv/dv_utils/"
+    set prim "$core_dir/vendor/lowrisc_ip/ip/prim/rtl/"
+} elseif {[string first "cv32e40x" $core_dir] != -1} {
+    set main_core "MAIN_CORE_CV32E40X"
+    lappend src_list "$core_dir/rtl/include/cv32e40x_pkg.sv"
+    foreach file [glob -type f $core_dir\/*rtl\/*\[a-z,_\]*.sv] {
+        lappend src_list $file
+    }
+    lappend src_list "$core_dir/bhv/cv32e40x_sim_clock_gate.sv"
+}
+foreach file [glob -type f $vproc_dir\/*rtl\/*\[a-z,_\]*.sv] {
+    lappend src_list $file
+}
+
+vlib work
+
+foreach file $src_list {vlog -work work $file +define+$main_core +incdir+$prim+$dv_utils}
+
+vopt +acc vproc_tb -o vproc_tb_opt -debugdb -G VREG_W=$VREG_W \
+     -G VMEM_W=$VMEM_W -G VMUL_W=$VMUL_W -G VALU_W=$VALU_W    \
+     -G VSLD_W=$VSLD_W -G ICACHE_SZ=$ICACHE_SZ                \
+     -G ICACHE_LINE_W=$ICACHE_LINE_W -G DCACHE_SZ=$DCACHE_SZ  \
+     -G DCACHE_LINE_W=$DCACHE_LINE_W -G MEM_W=$MEM_W          \
+     -G MEM_SZ=$MEM_SZ -G MEM_LATENCY=$MEM_LATENCY            \
+     -G RAM_TYPE=$RAM_TYPE -G MUl_TYPE=$MUL_TYPE              \
+     +define+$main_core -G PROG_PATHS_LIST=$prog_paths_var
+
+vsim -work work vproc_tb_opt
+
+# add trace_signals
+foreach sig $log_signals {
+    add wave $sig
+}
+
+set complete_signal "done"
+add wave "done"
+
+set outf [open $log_file_path "w"]
+puts "logging following signals to $log_file_path: $log_signals"
+
+foreach sig $log_signals {
+    set sig_name_start [string wordstart $sig end]
+    puts -nonewline $outf "[string range $sig $sig_name_start end];"
+}
+puts $outf ""
+
+for {set step 0} 1 {incr step} {
+    # log the value of each signal
+    foreach sig $log_signals {
+        puts -nonewline $outf "[examine -noshowbase $sig];"
+    }
+    puts $outf ""
+    # advance by 1 clock cycle
+    run 10 ns
+
+    # check if the abort condition has been met
+    if {[examine -noshowbase $complete_signal] == "1"} {
+        puts "exit condition met after $step clock cycles"
+        break
+    }
+}
+
+exit -f

--- a/sim/sim_questa.tcl
+++ b/sim/sim_questa.tcl
@@ -1,19 +1,6 @@
-# Copyright 2022 CSEM
-#
-# This file, and derivatives thereof are licensed under the
-# Solderpad License, Version 2.0 (the "License");
-# Use of this file means you agree to the terms and conditions
-# of the license and are in full compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://solderpad.org/licenses/SHL-2.0/
-#
-# Unless required by applicable law or agreed to in writing, software
-# and hardware implementations thereof
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright CSEM
+# Licensed under the Solderpad Hardware License v2.1, see LICENSE.txt for details
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 
 
 if {$argc < 5} {

--- a/test/README.md
+++ b/test/README.md
@@ -14,10 +14,11 @@ environment variable `CORE`.
 
 The default simulator used for the tests is
 [Verilator](https://www.veripool.org/verilator/).  This can be changed by
-setting the environment variable `SIMULATOR`.  Currently only Verilator and
+setting the environment variable `SIMULATOR`.  Currently only Verilator, 
 xsim (part of the
 [Xilinx Vivado](https://www.xilinx.com/products/design-tools/vivado.html)
-suite, set `SIMULATOR` to `vivado` to use it) are supported.
+suite, set `SIMULATOR` to `vivado` to use it) and Questasim (set `SIMULATOR`
+to `questa` to use it) are supported.
 
 By default tracing is disabled in Verilator.  Use the environment variable
 `TRACE_VCD` to specify a `*.vcd` file path if you wish to generate a VCD trace


### PR DESCRIPTION
Hi @michael-platzer ,

I have added a ASIC register file and support for the QuestaSim simulator. I will quickly go over the three commits, because they also contain some small RTL changes as well as some non obvious changes.

#### https://github.com/moimfeld/vicuna/commit/3aec11ca7b1687f04029f57d234701e053aa948c
In this commit I have added the ASIC register file and I have also added a `RAM_ASIC` to the `ram_type` enumeration in the vproc_pkg. I have also added values to the `ram_type` and `mul_type` enumerations in the vproc_pkg such that I can set the parameter `RAM_TAPE` and `MUL_TYPE` when compiling the source files for simulation.

#### https://github.com/moimfeld/vicuna/commit/a3115ed6e043fa6c5aafbb741a439337a23d669b
Here I changed a few lines of the RTL because they were not SystemVerilog compliant according to QuestaSim. While compiling the files I always got this Error:

	Error: ../rtl/vproc_core.sv(804): (vopt-12003) Variable 'vregfile_rd_addr' written by continuous and procedural assignments. See ../rtl/vproc_core.sv(718).

The issue is that you cannot assign part of a SystemVerilog array in a continuous way and another part of the same array in a for loop inside a combinational block.
You can find a more detailed explanation for the issue [here](https://verificationacademy.com/forums/systemverilog/continues-and-procedural-assignments-concurrently-same-variable).

I also had to remove the default assignment that sets `mem` to 0 in the `vproc_tb` in the initial block. I added a few lines in the always_ff block that sets all don't care values of the `mem` to  0 on the first clock edge, which should have them same effect.

#### https://github.com/moimfeld/vicuna/commit/e40ebd29104d03a0e1515636aedeb81d69cb8fa2
Here I added the QuestaSim as a simulator option. I have to highlight that I did change the way in which the `DCACHE_LINE_W` parameter is set in the sim/Makefile, because I had problems passing it to QuestaSim. I hope this does not impact Verilator or Vivado.


#### Side Note
I did not add the reset to ASIC register file, because we discussed here https://github.com/vproc/vicuna/issues/48 that it should not be necessary. This means the QuestaSim environment will not work for all tests until that issue is fixed.