### PR TITLE
Explicitly wirte vsetvli operands and make tests RISC-V V compliant

### DIFF
--- a/test/alu/vaadd_16.S
+++ b/test/alu/vaadd_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vaadd_32.S
+++ b/test/alu/vaadd_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vaadd_8.S
+++ b/test/alu/vaadd_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vaaddu_16.S
+++ b/test/alu/vaaddu_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vaaddu_32.S
+++ b/test/alu/vaaddu_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vaaddu_8.S
+++ b/test/alu/vaaddu_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vadc_16.S
+++ b/test/alu/vadc_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x8000
 

--- a/test/alu/vadc_32.S
+++ b/test/alu/vadc_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x80000000
 

--- a/test/alu/vadc_8.S
+++ b/test/alu/vadc_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x80
 

--- a/test/alu/vadd_16.S
+++ b/test/alu/vadd_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vadd_32.S
+++ b/test/alu/vadd_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vadd_8.S
+++ b/test/alu/vadd_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vand_16.S
+++ b/test/alu/vand_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x5a4b
 

--- a/test/alu/vand_32.S
+++ b/test/alu/vand_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x5a4b3c2d
 

--- a/test/alu/vand_8.S
+++ b/test/alu/vand_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x5a
 

--- a/test/alu/vasub_16.S
+++ b/test/alu/vasub_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vasub_32.S
+++ b/test/alu/vasub_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vasub_8.S
+++ b/test/alu/vasub_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vasubu_16.S
+++ b/test/alu/vasubu_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vasubu_32.S
+++ b/test/alu/vasubu_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vasubu_8.S
+++ b/test/alu/vasubu_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vmand.S
+++ b/test/alu/vmand.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x5a
     vmv.v.x         v0, t0

--- a/test/alu/vmandnot.S
+++ b/test/alu/vmandnot.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x5a
     vmv.v.x         v0, t0

--- a/test/alu/vmax_16.S
+++ b/test/alu/vmax_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 5
 

--- a/test/alu/vmax_32.S
+++ b/test/alu/vmax_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 5
 

--- a/test/alu/vmax_8.S
+++ b/test/alu/vmax_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 5
 

--- a/test/alu/vmaxu_16.S
+++ b/test/alu/vmaxu_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x8000
 

--- a/test/alu/vmaxu_32.S
+++ b/test/alu/vmaxu_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x80000000
 

--- a/test/alu/vmaxu_8.S
+++ b/test/alu/vmaxu_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x80
 

--- a/test/alu/vmerge_16.S
+++ b/test/alu/vmerge_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x55aa
 

--- a/test/alu/vmerge_32.S
+++ b/test/alu/vmerge_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e32,m4
+    vsetvli         t0, t0, e32,m4,tu,mu
 
     li              t0, 0x55aa55aa
 

--- a/test/alu/vmerge_8.S
+++ b/test/alu/vmerge_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x55
 

--- a/test/alu/vmin_16.S
+++ b/test/alu/vmin_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0
 

--- a/test/alu/vmin_32.S
+++ b/test/alu/vmin_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0
 

--- a/test/alu/vmin_8.S
+++ b/test/alu/vmin_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0
 

--- a/test/alu/vminu_16.S
+++ b/test/alu/vminu_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x8000
 

--- a/test/alu/vminu_32.S
+++ b/test/alu/vminu_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x80000000
 

--- a/test/alu/vminu_8.S
+++ b/test/alu/vminu_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x80
 

--- a/test/alu/vmnand.S
+++ b/test/alu/vmnand.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x5a
     vmv.v.x         v0, t0

--- a/test/alu/vmnor.S
+++ b/test/alu/vmnor.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x5a
     vmv.v.x         v0, t0

--- a/test/alu/vmor.S
+++ b/test/alu/vmor.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x5a
     vmv.v.x         v0, t0

--- a/test/alu/vmornot.S
+++ b/test/alu/vmornot.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x5a
     vmv.v.x         v0, t0

--- a/test/alu/vmseq_16.S
+++ b/test/alu/vmseq_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x323b
     li              t1, 0xffff

--- a/test/alu/vmseq_32.S
+++ b/test/alu/vmseq_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x323bbf47
     li              t1, 0xffffffff

--- a/test/alu/vmseq_8.S
+++ b/test/alu/vmseq_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x32
     li              t1, 0xff

--- a/test/alu/vmsgt_16.S
+++ b/test/alu/vmsgt_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x2e32
     li              t1, 0xffff

--- a/test/alu/vmsgt_32.S
+++ b/test/alu/vmsgt_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x302f2e32
     li              t1, 0xffffffff

--- a/test/alu/vmsgt_8.S
+++ b/test/alu/vmsgt_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x2e
     li              t1, 0xff

--- a/test/alu/vmsgtu_16.S
+++ b/test/alu/vmsgtu_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x4a51
     li              t1, 0xffff

--- a/test/alu/vmsgtu_32.S
+++ b/test/alu/vmsgtu_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x323bbf47
     li              t1, 0xffffffff

--- a/test/alu/vmsgtu_8.S
+++ b/test/alu/vmsgtu_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x51
     li              t1, 0xff

--- a/test/alu/vmsle_16.S
+++ b/test/alu/vmsle_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x2e32
     li              t1, 0xffff

--- a/test/alu/vmsle_32.S
+++ b/test/alu/vmsle_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x302f2e32
     li              t1, 0xffffffff

--- a/test/alu/vmsle_8.S
+++ b/test/alu/vmsle_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x2e
     li              t1, 0xff

--- a/test/alu/vmsleu_16.S
+++ b/test/alu/vmsleu_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x4a51
     li              t1, 0xffff

--- a/test/alu/vmsleu_32.S
+++ b/test/alu/vmsleu_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x323bbf47
     li              t1, 0xffffffff

--- a/test/alu/vmsleu_8.S
+++ b/test/alu/vmsleu_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x51
     li              t1, 0xff

--- a/test/alu/vmslt_16.S
+++ b/test/alu/vmslt_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x2e32
     li              t1, 0xffff

--- a/test/alu/vmslt_32.S
+++ b/test/alu/vmslt_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x302f2e32
     li              t1, 0xffffffff

--- a/test/alu/vmslt_8.S
+++ b/test/alu/vmslt_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x2e
     li              t1, 0xff

--- a/test/alu/vmsltu_16.S
+++ b/test/alu/vmsltu_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x4a51
     li              t1, 0xffff

--- a/test/alu/vmsltu_32.S
+++ b/test/alu/vmsltu_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x323bbf47
     li              t1, 0xffffffff

--- a/test/alu/vmsltu_8.S
+++ b/test/alu/vmsltu_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x51
     li              t1, 0xff

--- a/test/alu/vmsne_16.S
+++ b/test/alu/vmsne_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x323b
     li              t1, 0xffff

--- a/test/alu/vmsne_32.S
+++ b/test/alu/vmsne_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x323bbf47
     li              t1, 0xffffffff

--- a/test/alu/vmsne_8.S
+++ b/test/alu/vmsne_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x32
     li              t1, 0xff

--- a/test/alu/vmv1r.S
+++ b/test/alu/vmv1r.S
@@ -9,19 +9,19 @@ main:
     la              a0, vdata_start
 
     li              t0, 128
-    vsetvli         t0, t0, e8,m8
+    vsetvli         t0, t0, e8,m8,tu,mu
 
     li              t0, 0x5a
     vmv.v.x         v0, t0
     vle8.v          v8, (a0)
 
     li              t0, 3
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vmv1r.v         v8, v0
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vse8.v          v8, (a0)
 

--- a/test/alu/vmv2r.S
+++ b/test/alu/vmv2r.S
@@ -9,19 +9,19 @@ main:
     la              a0, vdata_start
 
     li              t0, 128
-    vsetvli         t0, t0, e8,m8
+    vsetvli         t0, t0, e8,m8,tu,mu
 
     li              t0, 0x5a
     vmv.v.x         v0, t0
     vle8.v          v8, (a0)
 
     li              t0, 3
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vmv2r.v         v8, v0
 
     li              t0, 32
-    vsetvli         t0, t0, e8,m2
+    vsetvli         t0, t0, e8,m2,tu,mu
 
     vse8.v          v8, (a0)
 

--- a/test/alu/vmv4r.S
+++ b/test/alu/vmv4r.S
@@ -9,19 +9,19 @@ main:
     la              a0, vdata_start
 
     li              t0, 128
-    vsetvli         t0, t0, e8,m8
+    vsetvli         t0, t0, e8,m8,tu,mu
 
     li              t0, 0x5a
     vmv.v.x         v0, t0
     vle8.v          v8, (a0)
 
     li              t0, 3
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vmv4r.v         v8, v0
 
     li              t0, 64
-    vsetvli         t0, t0, e8,m4
+    vsetvli         t0, t0, e8,m4,tu,mu
 
     vse8.v          v8, (a0)
 

--- a/test/alu/vmv8r.S
+++ b/test/alu/vmv8r.S
@@ -9,19 +9,19 @@ main:
     la              a0, vdata_start
 
     li              t0, 128
-    vsetvli         t0, t0, e8,m8
+    vsetvli         t0, t0, e8,m8,tu,mu
 
     li              t0, 0x5a
     vmv.v.x         v0, t0
     vle8.v          v8, (a0)
 
     li              t0, 3
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vmv8r.v         v8, v0
 
     li              t0, 128
-    vsetvli         t0, t0, e8,m8
+    vsetvli         t0, t0, e8,m8,tu,mu
 
     vse8.v          v8, (a0)
 

--- a/test/alu/vmv_16.S
+++ b/test/alu/vmv_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vle16.v         v0, (a0)
     vmv.v.v         v2, v0

--- a/test/alu/vmv_32.S
+++ b/test/alu/vmv_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     vle32.v         v0, (a0)
     vmv.v.v         v2, v0

--- a/test/alu/vmv_8.S
+++ b/test/alu/vmv_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle8.v          v0, (a0)
     vmv.v.v         v2, v0

--- a/test/alu/vmv_s_x_16.S
+++ b/test/alu/vmv_s_x_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 32
-    vsetvli         t0, t0, e16,m4
+    vsetvli         t0, t0, e16,m4,tu,mu
 
     vle8.v          v0, (a0)
     li              t0, 0x55aa

--- a/test/alu/vmv_s_x_32.S
+++ b/test/alu/vmv_s_x_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e32,m2
+    vsetvli         t0, t0, e32,m2,tu,mu
 
     vle8.v          v0, (a0)
     li              t0, 0x5555aaaa

--- a/test/alu/vmv_s_x_8.S
+++ b/test/alu/vmv_s_x_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle8.v          v0, (a0)
     li              t0, 0x5a

--- a/test/alu/vmxnor.S
+++ b/test/alu/vmxnor.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x5a
     vmv.v.x         v0, t0

--- a/test/alu/vmxor.S
+++ b/test/alu/vmxor.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x5a
     vmv.v.x         v0, t0

--- a/test/alu/vnclip_16.S
+++ b/test/alu/vnclip_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vle32.v         v0, (a0)
     vnclip.wi       v0, v0, 15

--- a/test/alu/vnclip_8.S
+++ b/test/alu/vnclip_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle16.v         v0, (a0)
     vnclip.wi       v0, v0, 7

--- a/test/alu/vnclipu_16.S
+++ b/test/alu/vnclipu_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vle32.v         v0, (a0)
     vnclipu.wi      v0, v0, 14

--- a/test/alu/vnclipu_8.S
+++ b/test/alu/vnclipu_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle16.v         v0, (a0)
     vnclipu.wi      v0, v0, 6

--- a/test/alu/vnsra_16.S
+++ b/test/alu/vnsra_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vle32.v         v0, (a0)
     vnsra.wi        v0, v0, 19

--- a/test/alu/vnsra_8.S
+++ b/test/alu/vnsra_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle16.v         v0, (a0)
     vnsra.wi        v0, v0, 9

--- a/test/alu/vnsrl_16.S
+++ b/test/alu/vnsrl_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vle32.v         v0, (a0)
     vnsrl.wi        v0, v0, 19

--- a/test/alu/vnsrl_8.S
+++ b/test/alu/vnsrl_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle16.v         v0, (a0)
     vnsrl.wi        v0, v0, 9

--- a/test/alu/vor_16.S
+++ b/test/alu/vor_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x5a4b
 

--- a/test/alu/vor_32.S
+++ b/test/alu/vor_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x5a4b3c2d
 

--- a/test/alu/vor_8.S
+++ b/test/alu/vor_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x5a
 

--- a/test/alu/vrsub_16.S
+++ b/test/alu/vrsub_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vrsub_32.S
+++ b/test/alu/vrsub_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vrsub_8.S
+++ b/test/alu/vrsub_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vsadd_16.S
+++ b/test/alu/vsadd_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x4000
 

--- a/test/alu/vsadd_32.S
+++ b/test/alu/vsadd_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x40000000
 

--- a/test/alu/vsadd_8.S
+++ b/test/alu/vsadd_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x40
 

--- a/test/alu/vsaddu_16.S
+++ b/test/alu/vsaddu_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0xc000
 

--- a/test/alu/vsaddu_32.S
+++ b/test/alu/vsaddu_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0xc0000000
 

--- a/test/alu/vsaddu_8.S
+++ b/test/alu/vsaddu_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0xc0
 

--- a/test/alu/vsbc_16.S
+++ b/test/alu/vsbc_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x8000
 

--- a/test/alu/vsbc_32.S
+++ b/test/alu/vsbc_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x80000000
 

--- a/test/alu/vsbc_8.S
+++ b/test/alu/vsbc_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x80
 

--- a/test/alu/vsext_16.S
+++ b/test/alu/vsext_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vle16.v         v0, (a0)
     vsext.vf2       v4, v0

--- a/test/alu/vsext_8.S
+++ b/test/alu/vsext_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle8.v          v0, (a0)
     vsext.vf2       v4, v0

--- a/test/alu/vsll_16.S
+++ b/test/alu/vsll_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vle16.v         v0, (a0)
     vsll.vi         v0, v0, 1

--- a/test/alu/vsll_32.S
+++ b/test/alu/vsll_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     vle32.v         v0, (a0)
     vsll.vi         v0, v0, 1

--- a/test/alu/vsll_8.S
+++ b/test/alu/vsll_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle8.v          v0, (a0)
     vsll.vi         v0, v0, 1

--- a/test/alu/vsra_16.S
+++ b/test/alu/vsra_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vle16.v         v0, (a0)
     vsra.vi         v0, v0, 1

--- a/test/alu/vsra_32.S
+++ b/test/alu/vsra_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     vle32.v         v0, (a0)
     vsra.vi         v0, v0, 1

--- a/test/alu/vsra_8.S
+++ b/test/alu/vsra_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle8.v          v0, (a0)
     vsra.vi         v0, v0, 1

--- a/test/alu/vsrl_16.S
+++ b/test/alu/vsrl_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vle16.v         v0, (a0)
     vsrl.vi         v0, v0, 1

--- a/test/alu/vsrl_32.S
+++ b/test/alu/vsrl_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     vle32.v         v0, (a0)
     vsrl.vi         v0, v0, 1

--- a/test/alu/vsrl_8.S
+++ b/test/alu/vsrl_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle8.v          v0, (a0)
     vsrl.vi         v0, v0, 1

--- a/test/alu/vssra_16.S
+++ b/test/alu/vssra_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vle16.v         v0, (a0)
     vssra.vi        v0, v0, 1

--- a/test/alu/vssra_32.S
+++ b/test/alu/vssra_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     vle32.v         v0, (a0)
     vssra.vi        v0, v0, 1

--- a/test/alu/vssra_8.S
+++ b/test/alu/vssra_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle8.v          v0, (a0)
     vssra.vi        v0, v0, 1

--- a/test/alu/vssrl_16.S
+++ b/test/alu/vssrl_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vle16.v         v0, (a0)
     vssrl.vi        v0, v0, 1

--- a/test/alu/vssrl_32.S
+++ b/test/alu/vssrl_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     vle32.v         v0, (a0)
     vssrl.vi        v0, v0, 1

--- a/test/alu/vssrl_8.S
+++ b/test/alu/vssrl_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle8.v          v0, (a0)
     vssrl.vi        v0, v0, 1

--- a/test/alu/vssub_16.S
+++ b/test/alu/vssub_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0xc000
 

--- a/test/alu/vssub_32.S
+++ b/test/alu/vssub_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0xc0000000
 

--- a/test/alu/vssub_8.S
+++ b/test/alu/vssub_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0xc0
 

--- a/test/alu/vssubu_16.S
+++ b/test/alu/vssubu_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x4000
 

--- a/test/alu/vssubu_32.S
+++ b/test/alu/vssubu_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x40000000
 

--- a/test/alu/vssubu_8.S
+++ b/test/alu/vssubu_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x40
 

--- a/test/alu/vsub_16.S
+++ b/test/alu/vsub_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vsub_32.S
+++ b/test/alu/vsub_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vsub_8.S
+++ b/test/alu/vsub_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vwadd-w_16.S
+++ b/test/alu/vwadd-w_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e16,m2
+    vsetvli         t0, t0, e16,m2,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vwadd-w_8.S
+++ b/test/alu/vwadd-w_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 32
-    vsetvli         t0, t0, e8,m2
+    vsetvli         t0, t0, e8,m2,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vwadd_16.S
+++ b/test/alu/vwadd_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e16,m2
+    vsetvli         t0, t0, e16,m2,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vwadd_8.S
+++ b/test/alu/vwadd_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 32
-    vsetvli         t0, t0, e8,m2
+    vsetvli         t0, t0, e8,m2,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vwaddu-w_16.S
+++ b/test/alu/vwaddu-w_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e16,m2
+    vsetvli         t0, t0, e16,m2,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vwaddu-w_8.S
+++ b/test/alu/vwaddu-w_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 32
-    vsetvli         t0, t0, e8,m2
+    vsetvli         t0, t0, e8,m2,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vwaddu_16.S
+++ b/test/alu/vwaddu_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e16,m2
+    vsetvli         t0, t0, e16,m2,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vwaddu_8.S
+++ b/test/alu/vwaddu_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 32
-    vsetvli         t0, t0, e8,m2
+    vsetvli         t0, t0, e8,m2,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vwsub-w_16.S
+++ b/test/alu/vwsub-w_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e16,m2
+    vsetvli         t0, t0, e16,m2,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vwsub-w_8.S
+++ b/test/alu/vwsub-w_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 32
-    vsetvli         t0, t0, e8,m2
+    vsetvli         t0, t0, e8,m2,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vwsub_16.S
+++ b/test/alu/vwsub_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e16,m2
+    vsetvli         t0, t0, e16,m2,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vwsub_8.S
+++ b/test/alu/vwsub_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 32
-    vsetvli         t0, t0, e8,m2
+    vsetvli         t0, t0, e8,m2,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vwsubu-w_16.S
+++ b/test/alu/vwsubu-w_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e16,m2
+    vsetvli         t0, t0, e16,m2,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vwsubu-w_8.S
+++ b/test/alu/vwsubu-w_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 32
-    vsetvli         t0, t0, e8,m2
+    vsetvli         t0, t0, e8,m2,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vwsubu_16.S
+++ b/test/alu/vwsubu_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e16,m2
+    vsetvli         t0, t0, e16,m2,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vwsubu_8.S
+++ b/test/alu/vwsubu_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 32
-    vsetvli         t0, t0, e8,m2
+    vsetvli         t0, t0, e8,m2,tu,mu
 
     li              t0, 1
 

--- a/test/alu/vxor_16.S
+++ b/test/alu/vxor_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x5a4b
 

--- a/test/alu/vxor_32.S
+++ b/test/alu/vxor_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x5a4b3c2d
 

--- a/test/alu/vxor_8.S
+++ b/test/alu/vxor_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x5a
 

--- a/test/alu/vzext_16.S
+++ b/test/alu/vzext_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vle16.v         v0, (a0)
     vzext.vf2       v4, v0

--- a/test/alu/vzext_8.S
+++ b/test/alu/vzext_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle8.v          v0, (a0)
     vzext.vf2       v4, v0

--- a/test/csr/vl.S
+++ b/test/csr/vl.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 13
-    vsetvli         t0, t0, e32,m4
+    vsetvli         t0, t0, e32,m4,tu,mu
 
     csrr            t0, vl
     vmv.v.x         v0, t0

--- a/test/csr/vsetvl_keep_vl.S
+++ b/test/csr/vsetvl_keep_vl.S
@@ -9,9 +9,9 @@ main:
     la              a0, vdata_start
 
     li              t0, 11
-    vsetvli         t0, t0, e16,m2
+    vsetvli         t0, t0, e16,m2,tu,mu
 
-    vsetvli         x0, x0, e8,m1
+    vsetvli         x0, x0, e8,m1,tu,mu
 
     li              t0, 0x5a
     vmv.v.x         v0, t0

--- a/test/csr/vtype.S
+++ b/test/csr/vtype.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e32,m4
+    vsetvli         t0, t0, e32,m4,tu,mu
 
     csrr            t0, vtype
     vmv.v.x         v0, t0

--- a/test/elem/vcompress_16.S
+++ b/test/elem/vcompress_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 9
-    vsetvli         t0, t0, e16,m2
+    vsetvli         t0, t0, e16,m2,tu,mu
 
     vle16.v         v0, (a0)
     vmv.v.x         v4, x0

--- a/test/elem/vcompress_32.S
+++ b/test/elem/vcompress_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 13
-    vsetvli         t0, t0, e32,m4
+    vsetvli         t0, t0, e32,m4,tu,mu
 
     vle32.v         v0, (a0)
     vmv.v.x         v4, x0

--- a/test/elem/vcompress_8.S
+++ b/test/elem/vcompress_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle8.v          v0, (a0)
     vmv.v.x         v2, x0

--- a/test/elem/vfirst_16.S
+++ b/test/elem/vfirst_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 32
-    vsetvli         t0, t0, e16,m4
+    vsetvli         t0, t0, e16,m4,tu,mu
 
     vle16.v         v0, (a0)
     vfirst.m        t0, v0

--- a/test/elem/vfirst_32.S
+++ b/test/elem/vfirst_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e32,m4
+    vsetvli         t0, t0, e32,m4,tu,mu
 
     vle32.v         v0, (a0)
     vfirst.m        t0, v0

--- a/test/elem/vfirst_8.S
+++ b/test/elem/vfirst_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 64
-    vsetvli         t0, t0, e8,m4
+    vsetvli         t0, t0, e8,m4,tu,mu
 
     vle8.v          v0, (a0)
     vfirst.m        t0, v0

--- a/test/elem/vid_16.S
+++ b/test/elem/vid_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 5
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vid.v           v0
     vse16.v         v0, (a0)

--- a/test/elem/vid_32.S
+++ b/test/elem/vid_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     vid.v           v0
     vse32.v         v0, (a0)

--- a/test/elem/vid_8.S
+++ b/test/elem/vid_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vid.v           v0
     vse8.v          v0, (a0)

--- a/test/elem/viota_16.S
+++ b/test/elem/viota_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 14
-    vsetvli         t0, t0, e16,m2
+    vsetvli         t0, t0, e16,m2,tu,mu
 
     vle16.v         v0, (a0)
     viota.m         v4, v0

--- a/test/elem/viota_32.S
+++ b/test/elem/viota_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 13
-    vsetvli         t0, t0, e32,m4
+    vsetvli         t0, t0, e32,m4,tu,mu
 
     vle32.v         v0, (a0)
     viota.m         v4, v0

--- a/test/elem/viota_8.S
+++ b/test/elem/viota_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle8.v          v0, (a0)
     viota.m         v2, v0

--- a/test/elem/vmv_xreg_16.S
+++ b/test/elem/vmv_xreg_16.S
@@ -9,13 +9,13 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vle16.v         v0, (a0)
     vmv.x.s         t1, v0
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     vmv.v.x         v0, t1
     vse32.v         v0, (a0)

--- a/test/elem/vmv_xreg_32.S
+++ b/test/elem/vmv_xreg_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     vle32.v         v0, (a0)
     vmv.x.s         t0, v0

--- a/test/elem/vmv_xreg_8.S
+++ b/test/elem/vmv_xreg_8.S
@@ -9,13 +9,13 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle8.v          v0, (a0)
     vmv.x.s         t1, v0
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     vmv.v.x         v0, t1
     vse32.v         v0, (a0)

--- a/test/elem/vpopc_16.S
+++ b/test/elem/vpopc_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 13
-    vsetvli         t0, t0, e16,m2
+    vsetvli         t0, t0, e16,m2,tu,mu
 
     vle16.v         v0, (a0)
     vpopc.m         t0, v0

--- a/test/elem/vpopc_32.S
+++ b/test/elem/vpopc_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 32
-    vsetvli         t0, t0, e32,m8
+    vsetvli         t0, t0, e32,m8,tu,mu
 
     vle32.v         v0, (a0)
     vpopc.m         t0, v0

--- a/test/elem/vpopc_8.S
+++ b/test/elem/vpopc_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 64
-    vsetvli         t0, t0, e8,m4
+    vsetvli         t0, t0, e8,m4,tu,mu
 
     vle8.v          v0, (a0)
     vpopc.m         t0, v0

--- a/test/elem/vredand_16.S
+++ b/test/elem/vredand_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x4178
     vmv.v.x         v0, t0

--- a/test/elem/vredand_32.S
+++ b/test/elem/vredand_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x4178fbc4
     vmv.v.x         v0, t0

--- a/test/elem/vredand_8.S
+++ b/test/elem/vredand_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x41
     vmv.v.x         v0, t0

--- a/test/elem/vredmax_16.S
+++ b/test/elem/vredmax_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x4178
     vmv.v.x         v0, t0

--- a/test/elem/vredmax_32.S
+++ b/test/elem/vredmax_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x4178fbc4
     vmv.v.x         v0, t0

--- a/test/elem/vredmax_8.S
+++ b/test/elem/vredmax_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x41
     vmv.v.x         v0, t0

--- a/test/elem/vredmaxu_16.S
+++ b/test/elem/vredmaxu_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x4178
     vmv.v.x         v0, t0

--- a/test/elem/vredmaxu_32.S
+++ b/test/elem/vredmaxu_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x4178fbc4
     vmv.v.x         v0, t0

--- a/test/elem/vredmaxu_8.S
+++ b/test/elem/vredmaxu_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x41
     vmv.v.x         v0, t0

--- a/test/elem/vredmin_16.S
+++ b/test/elem/vredmin_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x4178
     vmv.v.x         v0, t0

--- a/test/elem/vredmin_32.S
+++ b/test/elem/vredmin_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x4178fbc4
     vmv.v.x         v0, t0

--- a/test/elem/vredmin_8.S
+++ b/test/elem/vredmin_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x41
     vmv.v.x         v0, t0

--- a/test/elem/vredminu_16.S
+++ b/test/elem/vredminu_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x4178
     vmv.v.x         v0, t0

--- a/test/elem/vredminu_32.S
+++ b/test/elem/vredminu_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x4178fbc4
     vmv.v.x         v0, t0

--- a/test/elem/vredminu_8.S
+++ b/test/elem/vredminu_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x41
     vmv.v.x         v0, t0

--- a/test/elem/vredor_16.S
+++ b/test/elem/vredor_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x4178
     vmv.v.x         v0, t0

--- a/test/elem/vredor_32.S
+++ b/test/elem/vredor_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x4178fbc4
     vmv.v.x         v0, t0

--- a/test/elem/vredor_8.S
+++ b/test/elem/vredor_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x41
     vmv.v.x         v0, t0

--- a/test/elem/vredsum_16.S
+++ b/test/elem/vredsum_16.S
@@ -9,19 +9,19 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x4178
     vmv.v.x         v3, t0
 
     li              t0, 15
-    vsetvli         t0, t0, e16,m2
+    vsetvli         t0, t0, e16,m2,tu,mu
 
     vle16.v         v4, (a0)
     vredsum.vs      v3, v4, v3
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vse16.v         v3, (a0)
 

--- a/test/elem/vredsum_32.S
+++ b/test/elem/vredsum_32.S
@@ -9,19 +9,19 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x4178fbc4
     vmv.v.x         v3, t0
 
     li              t0, 29
-    vsetvli         t0, t0, e32,m8
+    vsetvli         t0, t0, e32,m8,tu,mu
 
     vle32.v         v8, (a0)
     vredsum.vs      v3, v8, v3
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     vse32.v         v3, (a0)
 

--- a/test/elem/vredsum_8.S
+++ b/test/elem/vredsum_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x41
     vmv.v.x         v0, t0

--- a/test/elem/vredxor_16.S
+++ b/test/elem/vredxor_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x4178
     vmv.v.x         v0, t0

--- a/test/elem/vredxor_32.S
+++ b/test/elem/vredxor_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x4178fbc4
     vmv.v.x         v0, t0

--- a/test/elem/vredxor_8.S
+++ b/test/elem/vredxor_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x41
     vmv.v.x         v0, t0

--- a/test/elem/vrgather_16.S
+++ b/test/elem/vrgather_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vle16.v         v0, (a0)
     addi            a1, a0, 64

--- a/test/elem/vrgather_32.S
+++ b/test/elem/vrgather_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e32,m4
+    vsetvli         t0, t0, e32,m4,tu,mu
 
     vle32.v         v0, (a0)
     addi            a1, a0, 64

--- a/test/elem/vrgather_8.S
+++ b/test/elem/vrgather_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle8.v          v0, (a0)
     addi            a1, a0, 64

--- a/test/elem/vwredsum_16.S
+++ b/test/elem/vwredsum_16.S
@@ -9,19 +9,19 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x4178
     vmv.v.x         v3, t0
 
     li              t0, 15
-    vsetvli         t0, t0, e16,m2
+    vsetvli         t0, t0, e16,m2,tu,mu
 
     vle16.v         v4, (a0)
     vwredsum.vs     v3, v4, v3
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vse16.v         v3, (a0)
 

--- a/test/elem/vwredsum_8.S
+++ b/test/elem/vwredsum_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x41
     vmv.v.x         v0, t0

--- a/test/elem/vwredsumu_16.S
+++ b/test/elem/vwredsumu_16.S
@@ -9,19 +9,19 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x4178
     vmv.v.x         v3, t0
 
     li              t0, 29
-    vsetvli         t0, t0, e16,m4
+    vsetvli         t0, t0, e16,m4,tu,mu
 
     vle16.v         v4, (a0)
     vwredsumu.vs    v3, v4, v3
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vse16.v         v3, (a0)
 

--- a/test/elem/vwredsumu_8.S
+++ b/test/elem/vwredsumu_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x41
     vmv.v.x         v0, t0

--- a/test/kernel/axpy.S
+++ b/test/kernel/axpy.S
@@ -25,7 +25,7 @@ main:
 #     a2      y
 #     a3      a
 
-    vsetvli         t0, a0, e8,m4
+    vsetvli         t0, a0, e8,m4,tu,mu
 
     mv              t2, a2
 

--- a/test/kernel/conv_3x3.S
+++ b/test/kernel/conv_3x3.S
@@ -8,7 +8,7 @@
     .global main
 main:
     li              t2, 65536
-    vsetvli         t2, t2, e8
+    vsetvli         t2, t2, e8,m1,tu,mu
     mv              a3, t2          # width is VLMAX
     li              a4, 65536       # total size is 65536 pixel
     la              a0, vdata_start

--- a/test/kernel/gemm.S
+++ b/test/kernel/gemm.S
@@ -63,7 +63,7 @@ gemm_nn:
     slti            t6, m, 8
     bnez            t6, end_rows
 
-    vsetvli         nvl, n, e8,m4  # 8-bit vectors, LMUL=4
+    vsetvli         nvl, n, e8,m4,tu,mu
 
 c_row_loop: # Loop across rows of C blocks
 

--- a/test/lsu/exc_vle_access.S
+++ b/test/lsu/exc_vle_access.S
@@ -10,7 +10,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle8.v          v0, (a0)
 

--- a/test/lsu/exc_vse_access.S
+++ b/test/lsu/exc_vse_access.S
@@ -10,7 +10,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle8.v          v0, (a0)
 

--- a/test/lsu/vl1r.S
+++ b/test/lsu/vl1r.S
@@ -10,18 +10,18 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x5a
     vmv.v.x         v0, t0
 
     li              t0, 3
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vl1r.v          v0, (a0)
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vse8.v          v0, (a0)
 

--- a/test/lsu/vl2r.S
+++ b/test/lsu/vl2r.S
@@ -10,18 +10,18 @@ main:
     la              a0, vdata_start
 
     li              t0, 32
-    vsetvli         t0, t0, e8,m2
+    vsetvli         t0, t0, e8,m2,tu,mu
 
     li              t0, 0x5a
     vmv.v.x         v0, t0
 
     li              t0, 3
-    vsetvli         t0, t0, e8,m2
+    vsetvli         t0, t0, e8,m2,tu,mu
 
     vl2r.v          v0, (a0)
 
     li              t0, 32
-    vsetvli         t0, t0, e8,m2
+    vsetvli         t0, t0, e8,m2,tu,mu
 
     vse8.v          v0, (a0)
 

--- a/test/lsu/vl4r.S
+++ b/test/lsu/vl4r.S
@@ -10,18 +10,18 @@ main:
     la              a0, vdata_start
 
     li              t0, 64
-    vsetvli         t0, t0, e8,m4
+    vsetvli         t0, t0, e8,m4,tu,mu
 
     li              t0, 0x5a
     vmv.v.x         v0, t0
 
     li              t0, 3
-    vsetvli         t0, t0, e8,m4
+    vsetvli         t0, t0, e8,m4,tu,mu
 
     vl4r.v          v0, (a0)
 
     li              t0, 64
-    vsetvli         t0, t0, e8,m4
+    vsetvli         t0, t0, e8,m4,tu,mu
 
     vse8.v          v0, (a0)
 

--- a/test/lsu/vl8r.S
+++ b/test/lsu/vl8r.S
@@ -10,18 +10,18 @@ main:
     la              a0, vdata_start
 
     li              t0, 128
-    vsetvli         t0, t0, e8,m8
+    vsetvli         t0, t0, e8,m8,tu,mu
 
     li              t0, 0x5a
     vmv.v.x         v0, t0
 
     li              t0, 3
-    vsetvli         t0, t0, e8,m8
+    vsetvli         t0, t0, e8,m8,tu,mu
 
     vl8r.v          v0, (a0)
 
     li              t0, 128
-    vsetvli         t0, t0, e8,m8
+    vsetvli         t0, t0, e8,m8,tu,mu
 
     vse8.v          v0, (a0)
 

--- a/test/lsu/vle16_16.S
+++ b/test/lsu/vle16_16.S
@@ -13,17 +13,18 @@ main:
     vsetvli         t0, t0, e16,m1,tu,mu
 
     vle16.v         v0, (a0)
+    vmv.v.v         v3, v0
 
     li              t0, 7
     vsetvli         t0, t0, e16,m1,tu,mu
 
     addi            a1, a0, 64
-    vle16.v         v0, (a1), v0.t
+    vle16.v         v3, (a1), v0.t
 
     li              t0, 8
     vsetvli         t0, t0, e16,m1,tu,mu
 
-    vse16.v         v0, (a0)
+    vse16.v         v3, (a0)
 
     la              a0, vdata_start
     la              a1, vdata_end

--- a/test/lsu/vle16_16.S
+++ b/test/lsu/vle16_16.S
@@ -10,18 +10,18 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vle16.v         v0, (a0)
 
     li              t0, 7
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     addi            a1, a0, 64
     vle16.v         v0, (a1), v0.t
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vse16.v         v0, (a0)
 

--- a/test/lsu/vle16_32.S
+++ b/test/lsu/vle16_32.S
@@ -10,20 +10,20 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e32,m2
+    vsetvli         t0, t0, e32,m2,tu,mu
 
     li              t0, 0x5a5a5a5a
     vmv.v.x         v0, t0
     vle16.v         v0, (a0)
 
     li              t0, 7
-    vsetvli         t0, t0, e32,m2
+    vsetvli         t0, t0, e32,m2,tu,mu
 
     addi            a1, a0, 64
     vle16.v         v0, (a1), v0.t
 
     li              t0, 8
-    vsetvli         t0, t0, e32,m2
+    vsetvli         t0, t0, e32,m2,tu,mu
 
     vse32.v         v0, (a0)
 

--- a/test/lsu/vle16_32.S
+++ b/test/lsu/vle16_32.S
@@ -15,17 +15,18 @@ main:
     li              t0, 0x5a5a5a5a
     vmv.v.x         v0, t0
     vle16.v         v0, (a0)
+    vmv.v.v         v2, v0
 
     li              t0, 7
     vsetvli         t0, t0, e32,m2,tu,mu
 
     addi            a1, a0, 64
-    vle16.v         v0, (a1), v0.t
+    vle16.v         v2, (a1), v0.t
 
     li              t0, 8
     vsetvli         t0, t0, e32,m2,tu,mu
 
-    vse32.v         v0, (a0)
+    vse32.v         v2, (a0)
 
     la              a0, vdata_start
     la              a1, vdata_end

--- a/test/lsu/vle16_8.S
+++ b/test/lsu/vle16_8.S
@@ -13,17 +13,18 @@ main:
     vsetvli         t0, t0, e8,m1,tu,mu
 
     vle16.v         v0, (a0)
+    vmv.v.v         v2, v0
 
     li              t0, 15
     vsetvli         t0, t0, e8,m1,tu,mu
 
     addi            a1, a0, 64
-    vle16.v         v0, (a1), v0.t
+    vle16.v         v2, (a1), v0.t
 
     li              t0, 16
     vsetvli         t0, t0, e8,m1,tu,mu
 
-    vse8.v          v0, (a0)
+    vse8.v          v2, (a0)
 
     la              a0, vdata_start
     la              a1, vdata_end

--- a/test/lsu/vle16_8.S
+++ b/test/lsu/vle16_8.S
@@ -10,18 +10,18 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle16.v         v0, (a0)
 
     li              t0, 15
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     addi            a1, a0, 64
     vle16.v         v0, (a1), v0.t
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vse8.v          v0, (a0)
 

--- a/test/lsu/vle32_16.S
+++ b/test/lsu/vle32_16.S
@@ -10,18 +10,18 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vle32.v         v0, (a0)
 
     li              t0, 7
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     addi            a1, a0, 64
     vle32.v         v0, (a1), v0.t
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vse16.v         v0, (a0)
 

--- a/test/lsu/vle32_16.S
+++ b/test/lsu/vle32_16.S
@@ -13,17 +13,18 @@ main:
     vsetvli         t0, t0, e16,m1,tu,mu
 
     vle32.v         v0, (a0)
+    vmv.v.v         v2, v0
 
     li              t0, 7
     vsetvli         t0, t0, e16,m1,tu,mu
 
     addi            a1, a0, 64
-    vle32.v         v0, (a1), v0.t
+    vle32.v         v2, (a1), v0.t
 
     li              t0, 8
     vsetvli         t0, t0, e16,m1,tu,mu
 
-    vse16.v         v0, (a0)
+    vse16.v         v2, (a0)
 
     la              a0, vdata_start
     la              a1, vdata_end

--- a/test/lsu/vle32_32.S
+++ b/test/lsu/vle32_32.S
@@ -10,18 +10,18 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e32,m2
+    vsetvli         t0, t0, e32,m2,tu,mu
 
     vle32.v         v0, (a0)
 
     li              t0, 7
-    vsetvli         t0, t0, e32,m2
+    vsetvli         t0, t0, e32,m2,tu,mu
 
     addi            a1, a0, 64
     vle32.v         v0, (a1), v0.t
 
     li              t0, 8
-    vsetvli         t0, t0, e32,m2
+    vsetvli         t0, t0, e32,m2,tu,mu
 
     vse32.v         v0, (a0)
 

--- a/test/lsu/vle32_32.S
+++ b/test/lsu/vle32_32.S
@@ -13,17 +13,18 @@ main:
     vsetvli         t0, t0, e32,m2,tu,mu
 
     vle32.v         v0, (a0)
+    vmv.v.v         v2, v0
 
     li              t0, 7
     vsetvli         t0, t0, e32,m2,tu,mu
 
     addi            a1, a0, 64
-    vle32.v         v0, (a1), v0.t
+    vle32.v         v2, (a1), v0.t
 
     li              t0, 8
     vsetvli         t0, t0, e32,m2,tu,mu
 
-    vse32.v         v0, (a0)
+    vse32.v         v2, (a0)
 
     la              a0, vdata_start
     la              a1, vdata_end

--- a/test/lsu/vle32_8.S
+++ b/test/lsu/vle32_8.S
@@ -13,17 +13,18 @@ main:
     vsetvli         t0, t0, e8,m1,tu,mu
 
     vle32.v         v0, (a0)
+    vmv.v.v         v8, v0
 
     li              t0, 15
     vsetvli         t0, t0, e8,m1,tu,mu
 
     addi            a1, a0, 64
-    vle32.v         v0, (a1), v0.t
+    vle32.v         v8, (a1), v0.t
 
     li              t0, 16
     vsetvli         t0, t0, e8,m1,tu,mu
 
-    vse8.v          v0, (a0)
+    vse8.v          v8, (a0)
 
     la              a0, vdata_start
     la              a1, vdata_end

--- a/test/lsu/vle32_8.S
+++ b/test/lsu/vle32_8.S
@@ -10,18 +10,18 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle32.v         v0, (a0)
 
     li              t0, 15
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     addi            a1, a0, 64
     vle32.v         v0, (a1), v0.t
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vse8.v          v0, (a0)
 

--- a/test/lsu/vle8_16.S
+++ b/test/lsu/vle8_16.S
@@ -10,20 +10,20 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x5a5a5a5a
     vmv.v.x         v0, t0
     vle8.v          v0, (a0)
 
     li              t0, 7
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     addi            a1, a0, 64
     vle8.v          v0, (a1), v0.t
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vse16.v         v0, (a0)
 

--- a/test/lsu/vle8_16.S
+++ b/test/lsu/vle8_16.S
@@ -15,17 +15,18 @@ main:
     li              t0, 0x5a5a5a5a
     vmv.v.x         v0, t0
     vle8.v          v0, (a0)
+    vmv.v.v         v2, v0
 
     li              t0, 7
     vsetvli         t0, t0, e16,m1,tu,mu
 
     addi            a1, a0, 64
-    vle8.v          v0, (a1), v0.t
+    vle8.v          v2, (a1), v0.t
 
     li              t0, 8
     vsetvli         t0, t0, e16,m1,tu,mu
 
-    vse16.v         v0, (a0)
+    vse16.v         v2, (a0)
 
     la              a0, vdata_start
     la              a1, vdata_end

--- a/test/lsu/vle8_32.S
+++ b/test/lsu/vle8_32.S
@@ -15,17 +15,18 @@ main:
     li              t0, 0x5a5a5a5a
     vmv.v.x         v0, t0
     vle8.v          v0, (a0)
+    vmv.v.v         v2, v0
 
     li              t0, 7
     vsetvli         t0, t0, e32,m2,tu,mu
 
     addi            a1, a0, 64
-    vle8.v          v0, (a1), v0.t
+    vle8.v          v2, (a1), v0.t
 
     li              t0, 8
     vsetvli         t0, t0, e32,m2,tu,mu
 
-    vse32.v         v0, (a0)
+    vse32.v         v2, (a0)
 
     la              a0, vdata_start
     la              a1, vdata_end

--- a/test/lsu/vle8_32.S
+++ b/test/lsu/vle8_32.S
@@ -10,20 +10,20 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e32,m2
+    vsetvli         t0, t0, e32,m2,tu,mu
 
     li              t0, 0x5a5a5a5a
     vmv.v.x         v0, t0
     vle8.v          v0, (a0)
 
     li              t0, 7
-    vsetvli         t0, t0, e32,m2
+    vsetvli         t0, t0, e32,m2,tu,mu
 
     addi            a1, a0, 64
     vle8.v          v0, (a1), v0.t
 
     li              t0, 8
-    vsetvli         t0, t0, e32,m2
+    vsetvli         t0, t0, e32,m2,tu,mu
 
     vse32.v         v0, (a0)
 

--- a/test/lsu/vle8_8.S
+++ b/test/lsu/vle8_8.S
@@ -10,18 +10,18 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle8.v          v0, (a0)
 
     li              t0, 15
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     addi            a1, a0, 64
     vle8.v          v0, (a1), v0.t
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vse8.v          v0, (a0)
 

--- a/test/lsu/vle8_8.S
+++ b/test/lsu/vle8_8.S
@@ -13,17 +13,18 @@ main:
     vsetvli         t0, t0, e8,m1,tu,mu
 
     vle8.v          v0, (a0)
+    vmv.v.v         v2, v0
 
     li              t0, 15
     vsetvli         t0, t0, e8,m1,tu,mu
 
     addi            a1, a0, 64
-    vle8.v          v0, (a1), v0.t
+    vle8.v          v2, (a1), v0.t
 
     li              t0, 16
     vsetvli         t0, t0, e8,m1,tu,mu
 
-    vse8.v          v0, (a0)
+    vse8.v          v2, (a0)
 
     la              a0, vdata_start
     la              a1, vdata_end

--- a/test/lsu/vloxei8_8.S
+++ b/test/lsu/vloxei8_8.S
@@ -10,7 +10,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0xb5
     vmv.v.x         v0, t0
@@ -19,14 +19,14 @@ main:
     vloxei8.v       v16, (a0), v8
 
     li              t0, 15
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     addi            a1, a0, 64
 
     vloxei8.v       v16, (a1), v8, v0.t
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vse8.v          v16, (a0)
 

--- a/test/lsu/vlse16.S
+++ b/test/lsu/vlse16.S
@@ -10,13 +10,13 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 6
     vlse16.v        v0, (a0), t0
 
     li              t0, 7
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     addi            a1, a0, 64
 
@@ -24,7 +24,7 @@ main:
     vlse16.v        v0, (a1), t0, v0.t
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vse16.v         v0, (a0)
 

--- a/test/lsu/vlse16.S
+++ b/test/lsu/vlse16.S
@@ -14,6 +14,7 @@ main:
 
     li              t0, 6
     vlse16.v        v0, (a0), t0
+    vmv.v.v         v2, v0
 
     li              t0, 7
     vsetvli         t0, t0, e16,m1,tu,mu
@@ -21,12 +22,12 @@ main:
     addi            a1, a0, 64
 
     li              t0, 6
-    vlse16.v        v0, (a1), t0, v0.t
+    vlse16.v        v2, (a1), t0, v0.t
 
     li              t0, 8
     vsetvli         t0, t0, e16,m1,tu,mu
 
-    vse16.v         v0, (a0)
+    vse16.v         v2, (a0)
 
     la              a0, vdata_start
     la              a1, vdata_end

--- a/test/lsu/vlse32.S
+++ b/test/lsu/vlse32.S
@@ -10,13 +10,13 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 12
     vlse32.v        v0, (a0), t0
 
     li              t0, 3
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     addi            a1, a0, 64
 
@@ -24,7 +24,7 @@ main:
     vlse32.v        v0, (a1), t0, v0.t
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     vse32.v         v0, (a0)
 

--- a/test/lsu/vlse32.S
+++ b/test/lsu/vlse32.S
@@ -14,6 +14,7 @@ main:
 
     li              t0, 12
     vlse32.v        v0, (a0), t0
+    vmv.v.v         v2, v0
 
     li              t0, 3
     vsetvli         t0, t0, e32,m1,tu,mu
@@ -21,12 +22,12 @@ main:
     addi            a1, a0, 64
 
     li              t0, 12
-    vlse32.v        v0, (a1), t0, v0.t
+    vlse32.v        v2, (a1), t0, v0.t
 
     li              t0, 4
     vsetvli         t0, t0, e32,m1,tu,mu
 
-    vse32.v         v0, (a0)
+    vse32.v         v2, (a0)
 
     la              a0, vdata_start
     la              a1, vdata_end

--- a/test/lsu/vlse8.S
+++ b/test/lsu/vlse8.S
@@ -10,13 +10,13 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 3
     vlse8.v         v0, (a0), t0
 
     li              t0, 15
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     addi            a1, a0, 64
 
@@ -24,7 +24,7 @@ main:
     vlse8.v         v0, (a1), t0, v0.t
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vse8.v          v0, (a0)
 

--- a/test/lsu/vlse8.S
+++ b/test/lsu/vlse8.S
@@ -14,6 +14,7 @@ main:
 
     li              t0, 3
     vlse8.v         v0, (a0), t0
+    vmv.v.v         v2, v0
 
     li              t0, 15
     vsetvli         t0, t0, e8,m1,tu,mu
@@ -21,12 +22,12 @@ main:
     addi            a1, a0, 64
 
     li              t0, 3
-    vlse8.v         v0, (a1), t0, v0.t
+    vlse8.v         v2, (a1), t0, v0.t
 
     li              t0, 16
     vsetvli         t0, t0, e8,m1,tu,mu
 
-    vse8.v          v0, (a0)
+    vse8.v          v2, (a0)
 
     la              a0, vdata_start
     la              a1, vdata_end

--- a/test/lsu/vs1r.S
+++ b/test/lsu/vs1r.S
@@ -10,7 +10,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 15
-    vsetvli         t0, t0, e8,m8
+    vsetvli         t0, t0, e8,m8,tu,mu
 
     vl1r.v          v0, (a0)
 
@@ -18,7 +18,7 @@ main:
     vmv.v.x         v0, t0
 
     li              t0, 3
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vs1r.v          v0, (a0)
 

--- a/test/lsu/vs2r.S
+++ b/test/lsu/vs2r.S
@@ -10,7 +10,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 29
-    vsetvli         t0, t0, e8,m8
+    vsetvli         t0, t0, e8,m8,tu,mu
 
     vl2r.v          v0, (a0)
 
@@ -18,7 +18,7 @@ main:
     vmv.v.x         v0, t0
 
     li              t0, 3
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vs2r.v          v0, (a0)
 

--- a/test/lsu/vs4r.S
+++ b/test/lsu/vs4r.S
@@ -10,7 +10,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 54
-    vsetvli         t0, t0, e8,m8
+    vsetvli         t0, t0, e8,m8,tu,mu
 
     vl4r.v          v0, (a0)
 
@@ -18,7 +18,7 @@ main:
     vmv.v.x         v0, t0
 
     li              t0, 3
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vs4r.v          v0, (a0)
 

--- a/test/lsu/vs8r.S
+++ b/test/lsu/vs8r.S
@@ -10,7 +10,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 91
-    vsetvli         t0, t0, e8,m8
+    vsetvli         t0, t0, e8,m8,tu,mu
 
     vl8r.v          v0, (a0)
 
@@ -18,7 +18,7 @@ main:
     vmv.v.x         v0, t0
 
     li              t0, 3
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vs8r.v          v0, (a0)
 

--- a/test/lsu/vse16_16.S
+++ b/test/lsu/vse16_16.S
@@ -10,14 +10,14 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0xb5
     vmv.v.x         v0, t0
     vse16.v         v0, (a0)
 
     li              t0, 7
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     addi            a0, a0, 64
     vse16.v         v0, (a0), v0.t

--- a/test/lsu/vse16_32.S
+++ b/test/lsu/vse16_32.S
@@ -10,14 +10,14 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e32,m2
+    vsetvli         t0, t0, e32,m2,tu,mu
 
     li              t0, 0xb5
     vmv.v.x         v0, t0
     vse16.v         v0, (a0)
 
     li              t0, 7
-    vsetvli         t0, t0, e32,m2
+    vsetvli         t0, t0, e32,m2,tu,mu
 
     addi            a0, a0, 64
     vse16.v         v0, (a0), v0.t

--- a/test/lsu/vse16_8.S
+++ b/test/lsu/vse16_8.S
@@ -10,19 +10,19 @@ main:
     la              a0, vdata_start
 
     li              t0, 32
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0xb5
     vmv.v.x         v0, t0
     vmv.v.x         v1, t0
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vse16.v         v0, (a0)
 
     li              t0, 15
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     addi            a0, a0, 64
     vse16.v         v0, (a0), v0.t

--- a/test/lsu/vse32_16.S
+++ b/test/lsu/vse32_16.S
@@ -10,19 +10,19 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0xb5
     vmv.v.x         v0, t0
     vmv.v.x         v1, t0
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vse32.v         v0, (a0)
 
     li              t0, 7
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     addi            a0, a0, 64
     vse32.v         v0, (a0), v0.t

--- a/test/lsu/vse32_32.S
+++ b/test/lsu/vse32_32.S
@@ -10,14 +10,14 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e32,m2
+    vsetvli         t0, t0, e32,m2,tu,mu
 
     li              t0, 0xb5
     vmv.v.x         v0, t0
     vse32.v         v0, (a0)
 
     li              t0, 7
-    vsetvli         t0, t0, e32,m2
+    vsetvli         t0, t0, e32,m2,tu,mu
 
     addi            a0, a0, 64
     vse32.v         v0, (a0), v0.t

--- a/test/lsu/vse32_8.S
+++ b/test/lsu/vse32_8.S
@@ -10,7 +10,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 64
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0xb5
     vmv.v.x         v0, t0
@@ -19,12 +19,12 @@ main:
     vmv.v.x         v3, t0
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vse32.v         v0, (a0)
 
     li              t0, 15
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     addi            a0, a0, 64
     vse32.v         v0, (a0), v0.t

--- a/test/lsu/vse8_16.S
+++ b/test/lsu/vse8_16.S
@@ -10,14 +10,14 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0xb5
     vmv.v.x         v0, t0
     vse8.v          v0, (a0)
 
     li              t0, 7
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     addi            a0, a0, 64
     vse8.v          v0, (a0), v0.t

--- a/test/lsu/vse8_32.S
+++ b/test/lsu/vse8_32.S
@@ -10,14 +10,14 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e32,m2
+    vsetvli         t0, t0, e32,m2,tu,mu
 
     li              t0, 0xb5
     vmv.v.x         v0, t0
     vse8.v          v0, (a0)
 
     li              t0, 7
-    vsetvli         t0, t0, e32,m2
+    vsetvli         t0, t0, e32,m2,tu,mu
 
     addi            a0, a0, 64
     vse8.v          v0, (a0), v0.t

--- a/test/lsu/vse8_8.S
+++ b/test/lsu/vse8_8.S
@@ -10,14 +10,14 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0xb5
     vmv.v.x         v0, t0
     vse8.v          v0, (a0)
 
     li              t0, 15
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     addi            a0, a0, 64
     vse8.v          v0, (a0), v0.t

--- a/test/lsu/vsoxei8_8.S
+++ b/test/lsu/vsoxei8_8.S
@@ -10,7 +10,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0xb5
     vmv.v.x         v0, t0
@@ -19,7 +19,7 @@ main:
     vsoxei8.v       v8, (a0), v8
 
     li              t0, 15
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     addi            a0, a0, 64
 

--- a/test/lsu/vsse16.S
+++ b/test/lsu/vsse16.S
@@ -10,7 +10,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0xb5
     vmv.v.x         v0, t0
@@ -19,7 +19,7 @@ main:
     vsse16.v        v0, (a0), t0
 
     li              t0, 7
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     addi            a0, a0, 64
 

--- a/test/lsu/vsse32.S
+++ b/test/lsu/vsse32.S
@@ -10,7 +10,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0xb5
     vmv.v.x         v0, t0
@@ -19,7 +19,7 @@ main:
     vsse32.v        v0, (a0), t0
 
     li              t0, 3
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     addi            a0, a0, 64
 

--- a/test/lsu/vsse8.S
+++ b/test/lsu/vsse8.S
@@ -10,7 +10,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0xb5
     vmv.v.x         v0, t0
@@ -19,7 +19,7 @@ main:
     vsse8.v         v0, (a0), t0
 
     li              t0, 15
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     addi            a0, a0, 64
 

--- a/test/mul/vmacc_16.S
+++ b/test/mul/vmacc_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 3
     vmv.v.i         v0, 7

--- a/test/mul/vmacc_32.S
+++ b/test/mul/vmacc_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 3
     vmv.v.i         v0, 7

--- a/test/mul/vmacc_8.S
+++ b/test/mul/vmacc_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 3
     vmv.v.i         v0, 7

--- a/test/mul/vmadd_16.S
+++ b/test/mul/vmadd_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 3
     vmv.v.i         v4, 7

--- a/test/mul/vmadd_32.S
+++ b/test/mul/vmadd_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 3
     vmv.v.i         v4, 7

--- a/test/mul/vmadd_8.S
+++ b/test/mul/vmadd_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 3
     vmv.v.i         v4, 7

--- a/test/mul/vmul_16.S
+++ b/test/mul/vmul_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 3
 

--- a/test/mul/vmul_32.S
+++ b/test/mul/vmul_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 3
 

--- a/test/mul/vmul_8.S
+++ b/test/mul/vmul_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 3
 

--- a/test/mul/vmulh_16.S
+++ b/test/mul/vmulh_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x8A96
 

--- a/test/mul/vmulh_32.S
+++ b/test/mul/vmulh_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x8A96BDD5
 

--- a/test/mul/vmulh_8.S
+++ b/test/mul/vmulh_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x8A
 

--- a/test/mul/vmulhsu_16.S
+++ b/test/mul/vmulhsu_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x8A96
 

--- a/test/mul/vmulhsu_32.S
+++ b/test/mul/vmulhsu_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x8A96BDD5
 

--- a/test/mul/vmulhsu_8.S
+++ b/test/mul/vmulhsu_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x8A
 

--- a/test/mul/vmulhu_16.S
+++ b/test/mul/vmulhu_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x8A96
 

--- a/test/mul/vmulhu_32.S
+++ b/test/mul/vmulhu_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x8A96BDD5
 

--- a/test/mul/vmulhu_8.S
+++ b/test/mul/vmulhu_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x8A
 

--- a/test/mul/vnmsac_16.S
+++ b/test/mul/vnmsac_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 3
     vmv.v.i         v0, 7

--- a/test/mul/vnmsac_32.S
+++ b/test/mul/vnmsac_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 3
     vmv.v.i         v0, 7

--- a/test/mul/vnmsac_8.S
+++ b/test/mul/vnmsac_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 3
     vmv.v.i         v0, 7

--- a/test/mul/vnmsub_16.S
+++ b/test/mul/vnmsub_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 3
     vmv.v.i         v4, 7

--- a/test/mul/vnmsub_32.S
+++ b/test/mul/vnmsub_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 3
     vmv.v.i         v4, 7

--- a/test/mul/vnmsub_8.S
+++ b/test/mul/vnmsub_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 3
     vmv.v.i         v4, 7

--- a/test/mul/vsmul_16.S
+++ b/test/mul/vsmul_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x74cd
     vle16.v         v0, (a0)

--- a/test/mul/vsmul_32.S
+++ b/test/mul/vsmul_32.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     li              t0, 0x74cd5a46
     vle32.v         v0, (a0)

--- a/test/mul/vsmul_8.S
+++ b/test/mul/vsmul_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x74
     vle8.v          v0, (a0)

--- a/test/mul/vwmacc_16.S
+++ b/test/mul/vwmacc_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x8a96
     vmv.v.x         v1, t0

--- a/test/mul/vwmacc_8.S
+++ b/test/mul/vwmacc_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x8a
     vmv.v.x         v1, t0

--- a/test/mul/vwmaccsu_16.S
+++ b/test/mul/vwmaccsu_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x8a96
     vmv.v.x         v1, t0

--- a/test/mul/vwmaccsu_8.S
+++ b/test/mul/vwmaccsu_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x8a
     vmv.v.x         v1, t0

--- a/test/mul/vwmaccu_16.S
+++ b/test/mul/vwmaccu_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x8a96
     vmv.v.x         v1, t0

--- a/test/mul/vwmaccu_8.S
+++ b/test/mul/vwmaccu_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x8a
     vmv.v.x         v1, t0

--- a/test/mul/vwmaccus_16.S
+++ b/test/mul/vwmaccus_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x8a96
     vmv.v.i         v0, 7

--- a/test/mul/vwmaccus_8.S
+++ b/test/mul/vwmaccus_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x8a
     vmv.v.i         v0, 7

--- a/test/mul/vwmul_16.S
+++ b/test/mul/vwmul_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x8a96
     vmv.v.x         v1, t0

--- a/test/mul/vwmul_8.S
+++ b/test/mul/vwmul_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x8a
     vmv.v.x         v1, t0

--- a/test/mul/vwmulsu_16.S
+++ b/test/mul/vwmulsu_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x8a96
     vmv.v.x         v1, t0

--- a/test/mul/vwmulsu_8.S
+++ b/test/mul/vwmulsu_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x8a
     vmv.v.x         v1, t0

--- a/test/mul/vwmulu_16.S
+++ b/test/mul/vwmulu_16.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     li              t0, 0x8a96
     vmv.v.x         v1, t0

--- a/test/mul/vwmulu_8.S
+++ b/test/mul/vwmulu_8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     li              t0, 0x8a
     vmv.v.x         v1, t0

--- a/test/sld/vslide1down_e16_m1.S
+++ b/test/sld/vslide1down_e16_m1.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 8
-    vsetvli         t0, t0, e16,m1
+    vsetvli         t0, t0, e16,m1,tu,mu
 
     vle16.v         v0, (a0)
     li              t0, 32

--- a/test/sld/vslide1down_e32_m4.S
+++ b/test/sld/vslide1down_e32_m4.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e32,m4
+    vsetvli         t0, t0, e32,m4,tu,mu
 
     vle32.v         v0, (a0)
     li              t0, 32

--- a/test/sld/vslide1down_e8_m2.S
+++ b/test/sld/vslide1down_e8_m2.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 32
-    vsetvli         t0, t0, e8,m2
+    vsetvli         t0, t0, e8,m2,tu,mu
 
     vle8.v          v0, (a0)
     li              t0, 32

--- a/test/sld/vslide1up_e16_m2.S
+++ b/test/sld/vslide1up_e16_m2.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e16,m2
+    vsetvli         t0, t0, e16,m2,tu,mu
 
     vle16.v         v0, (a0)
     li              t0, 32

--- a/test/sld/vslide1up_e32_m4.S
+++ b/test/sld/vslide1up_e32_m4.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e32,m4
+    vsetvli         t0, t0, e32,m4,tu,mu
 
     vle32.v         v0, (a0)
     li              t0, 32

--- a/test/sld/vslide1up_e8_m8.S
+++ b/test/sld/vslide1up_e8_m8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 128
-    vsetvli         t0, t0, e8,m8
+    vsetvli         t0, t0, e8,m8,tu,mu
 
     vle8.v          v0, (a0)
     li              t0, 32

--- a/test/sld/vslidedown00-sew08-mul1.S
+++ b/test/sld/vslidedown00-sew08-mul1.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8,m1
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle8.v          v0, (a0)
     vslidedown.vi   v8, v0, 0

--- a/test/sld/vslidedown01-sew08-mul1.S
+++ b/test/sld/vslidedown01-sew08-mul1.S
@@ -9,12 +9,12 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8,m1
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle8.v          v0, (a0)
 
     li              t0, 15
-    vsetvli         t0, t0, e8,m1
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vslidedown.vi   v0, v0, 1
     vse8.v          v0, (a0)

--- a/test/sld/vslidedown01-sew16-mul4.S
+++ b/test/sld/vslidedown01-sew16-mul4.S
@@ -9,12 +9,12 @@ main:
     la              a0, vdata_start
 
     li              t0, 32
-    vsetvli         t0, t0, e16,m4
+    vsetvli         t0, t0, e16,m4,tu,mu
 
     vle16.v         v0, (a0)
 
     li              t0, 31
-    vsetvli         t0, t0, e16,m4
+    vsetvli         t0, t0, e16,m4,tu,mu
 
     vslidedown.vi   v0, v0, 1
     vse16.v         v0, (a0)

--- a/test/sld/vslidedown01-sew32-mul1.S
+++ b/test/sld/vslidedown01-sew32-mul1.S
@@ -9,12 +9,12 @@ main:
     la              a0, vdata_start
 
     li              t0, 4
-    vsetvli         t0, t0, e32,m1
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     vle32.v         v0, (a0)
 
     li              t0, 3
-    vsetvli         t0, t0, e32,m1
+    vsetvli         t0, t0, e32,m1,tu,mu
 
     vslidedown.vi   v0, v0, 1
     vse32.v         v0, (a0)

--- a/test/sld/vslidedown12-sew08-mul1.S
+++ b/test/sld/vslidedown12-sew08-mul1.S
@@ -9,12 +9,12 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8,m1
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle8.v          v0, (a0)
 
     li              t0, 4
-    vsetvli         t0, t0, e8,m1
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vslidedown.vi   v0, v0, 12
     vse8.v          v0, (a0)

--- a/test/sld/vslidedown19-sew08-mul2.S
+++ b/test/sld/vslidedown19-sew08-mul2.S
@@ -9,12 +9,12 @@ main:
     la              a0, vdata_start
 
     li              t0, 32
-    vsetvli         t0, t0, e8,m2
+    vsetvli         t0, t0, e8,m2,tu,mu
 
     vle8.v          v0, (a0)
 
     li              t0, 13
-    vsetvli         t0, t0, e8,m2
+    vsetvli         t0, t0, e8,m2,tu,mu
 
     vslidedown.vi   v0, v0, 19
     vse8.v          v0, (a0)

--- a/test/sld/vslideup00-sew08-mul1.S
+++ b/test/sld/vslideup00-sew08-mul1.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8,m1
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle8.v          v0, (a0)
     vslideup.vi     v8, v0, 0

--- a/test/sld/vslideup01-sew08-mul8.S
+++ b/test/sld/vslideup01-sew08-mul8.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 128
-    vsetvli         t0, t0, e8,m8
+    vsetvli         t0, t0, e8,m8,tu,mu
 
     vmv.v.x         v8, x0
 

--- a/test/sld/vslideup08-sew08-mul1.S
+++ b/test/sld/vslideup08-sew08-mul1.S
@@ -12,8 +12,9 @@ main:
     vsetvli         t0, t0, e8,m1,tu,mu
 
     vle8.v          v0, (a0)
-    vslideup.vi     v0, v0, 8
-    vse8.v          v0, (a0)
+    vmv.v.v         v2, v0
+    vslideup.vi     v2, v0, 8
+    vse8.v          v2, (a0)
 
     la              a0, vdata_start
     la              a1, vdata_end

--- a/test/sld/vslideup08-sew08-mul1.S
+++ b/test/sld/vslideup08-sew08-mul1.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 16
-    vsetvli         t0, t0, e8,m1
+    vsetvli         t0, t0, e8,m1,tu,mu
 
     vle8.v          v0, (a0)
     vslideup.vi     v0, v0, 8

--- a/test/sld/vslideup13-sew16-mul4.S
+++ b/test/sld/vslideup13-sew16-mul4.S
@@ -9,7 +9,7 @@ main:
     la              a0, vdata_start
 
     li              t0, 32
-    vsetvli         t0, t0, e16,m4
+    vsetvli         t0, t0, e16,m4,tu,mu
 
     vmv.v.x         v8, x0
 


### PR DESCRIPTION
Hi @michael-platzer

I have tried to compile the test programs using LLVM + Clang and encountered some issues.

### 1. Problem
LLVM + Clang wants to have all operands of the vsetvli explicitly written in the assembly.
#### Solution
I have changed all vsetvli instructions in all tests files such that they have all operands explicitly written. I preserved all operands that were already explicitly written before my addition/change.
I set all configurations to tail-undisturbed and mask-undisturbed that did not already have a tail/mask policy. If you prefer a different policy I can change it accordingly (I have a script that can make the change).

### 2. Problem
LLVM + Clang threw an error for the following instructions:

`test/lsu/vle16_16.S`
`test/lsu/vle16_32.S`
`test/lsu/vle16_8.S`
`test/lsu/vle32_16.S`
`test/lsu/vle32_32.S`
`test/lsu/vle32_8.S`
`test/lsu/vle8_16.S`
`test/lsu/vle8_32.S`
`test/lsu/vle8_8.S`
`test/lsu/vlse16.S`
`test/lsu/vlse32.S`
`test/lsu/vlse8.S`
`test/sld/vslideup08-sew08-mul1.S`

And the error message was:

	error: The destination vector register group cannot overlap the mask register.
	    vle32.v v0, (a1), v0.t
	            ^
I think the compiler is right to throw this error, since section 5.2 of the RISC-V "V" specification lists some conditions under which overlaps can occur (and the instructions here do not fall under those conditions).

#### Solution
I changed the destination register such that there are no more illegal overlaps. To get the tests to complete successfully I also had to add some move instructions and change the register that is stored.


### Note
I compiled and ran all test (with these changes) with gcc and llvm. Both completed successfully.