### PR TITLE
Add LLVM + Clang as a compiler option

### DIFF
--- a/sw/Makefile
+++ b/sw/Makefile
@@ -8,14 +8,26 @@
 
 SW_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
-RISCV_CC   := riscv32-unknown-elf-gcc
-RISCV_DUMP := riscv32-unknown-elf-objdump
-RISCV_OBCP := riscv32-unknown-elf-objcopy
+COMPILER ?= gcc
+ifeq ($(COMPILER),gcc)
+    RISCV_CC            := riscv32-unknown-elf-gcc
+    RISCV_DUMP          := riscv32-unknown-elf-objdump
+    RISCV_OBCP          := riscv32-unknown-elf-objcopy
+    ARCH                := rv32imv
+    LD_SCRIPT           := $(SW_DIR)/link.ld
+else ifeq ($(COMPILER),llvm)
+    RISCV_CC            := clang
+    RISCV_DUMP          := llvm-objdump
+    RISCV_OBCP          := llvm-objcopy
+    ARCH                := rv32imzve32x
+    CC_SPECIFIC_OPTIONS := -fuse-ld=lld
+    LD_SCRIPT           := $(SW_DIR)/lld_link.ld
+endif
 
-LD_SCRIPT := $(SW_DIR)/link.ld
 
-RISCV_FLAGS := -march=rv32imv -mabi=ilp32 -static -mcmodel=medany             \
-               -fvisibility=hidden -nostdlib -nostartfiles -Wall
+RISCV_FLAGS := -march=$(ARCH) -mabi=ilp32 -static -mcmodel=medany             \
+               -fvisibility=hidden -nostdlib -nostartfiles -Wall              \
+               $(CC_SPECIFIC_OPTIONS)
 
 CFLAGS := $(CFLAGS) -I$(SW_DIR)/lib/
 
@@ -53,3 +65,5 @@ $(PROG).elf: $(RISCV_OBJ) $(LD_SCRIPT)
 
 clean:
 	rm -f *.o *.elf *.bin *.vmem
+
+include $(SW_DIR)/toolchain.mk

--- a/sw/README.md
+++ b/sw/README.md
@@ -32,6 +32,17 @@ mkdir build && cd build
 make
 ```
 
+Execute the following command to compile LLVM + Clang with
+V extension support enabled.  Note that `/desired/installation/path` should be
+replaced with the path where the toolchain should be cloned to and installed in.
+Please refer to the documentation on the
+[LLVM Website](https://llvm.org/docs/GettingStarted.html)
+for the required prerequisites for compiling the toolchain.
+
+```
+make llvm LLVM_DIR=/desired/installation/path
+```
+
 
 ## Usage
 

--- a/sw/lld_link.ld
+++ b/sw/lld_link.ld
@@ -1,0 +1,95 @@
+/* Copyright TU Wien                                                          */
+/* Licensed under the Solderpad Hardware License v2.1, see LICENSE.txt for details                */
+/* SPDX-License-Identifier: SHL-2.1                                               */
+
+
+OUTPUT_ARCH(riscv)
+ENTRY(_start)
+
+SEARCH_DIR(.)
+__DYNAMIC = 0;
+
+MEMORY
+{
+    boot : ORIGIN = 0x00000000, LENGTH = 0x00002000 /*   8 kB */
+    ram  : ORIGIN = 0x00002000, LENGTH = 0x0003E000 /* 248 kB */
+}
+
+STACK_LEN = 0x4000; /* 16 kB */
+
+SECTIONS
+{
+    .vectors 0 : {
+        *(.vectors)
+    } >boot
+
+    .text : {
+        . = ALIGN(4);
+        _stext = .;
+        *(.text)
+        *(.text.*)
+        _etext  =  .;
+        __CTOR_LIST__ = .;
+        LONG((__CTOR_END__ - __CTOR_LIST__) / 4 - 2)
+        *(.ctors)
+        LONG(0)
+        __CTOR_END__ = .;
+        __DTOR_LIST__ = .;
+        LONG((__DTOR_END__ - __DTOR_LIST__) / 4 - 2)
+        *(.dtors)
+        LONG(0)
+        __DTOR_END__ = .;
+        *(.lit)
+        *(.shdata)
+        . = ALIGN(4);
+        _endtext = .;
+    } >ram
+
+    .rodata : {
+        . = ALIGN(4);
+        *(.rodata);
+        *(.rodata.*)
+    } >ram
+
+    .shbss : {
+        . = ALIGN(4);
+        *(.shbss)
+    } >ram
+
+    .data : {
+        . = ALIGN(4);
+        sdata = .;
+        _sdata = .;
+        *(.data);
+        *(.data.*)
+        edata = .;
+        _edata = .;
+    } >ram
+
+    .bss (NOLOAD) : {
+        . = ALIGN(4);
+        _bss_start = .;
+        *(.bss)
+        *(.bss.*)
+        *(.sbss)
+        *(.sbss.*)
+        *(COMMON)
+        _bss_end = .;
+    } >ram
+
+    .user_align (NOLOAD) : {
+        . = ALIGN(0x1000);
+        _user_start = .;
+    } >ram
+
+
+    .stack ORIGIN(ram) + LENGTH(ram) - STACK_LEN (NOLOAD) : {
+        . = ALIGN(16);
+        _stack_start = .;
+        . = . + STACK_LEN;
+        . = ALIGN(16);
+        stack = .;
+        _stack = .;
+        _stack_end = .;
+    } >ram
+}

--- a/sw/toolchain.mk
+++ b/sw/toolchain.mk
@@ -1,0 +1,53 @@
+# Copyright CSEM
+# Licensed under the Solderpad Hardware License v2.1, see LICENSE.txt for details
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+CMAKE                      := cmake
+CC                         := gcc
+
+LLVM_INSTALL_DIR           := $(LLVM_DIR)/install
+LLVM_REPO                  := https://github.com/llvm/llvm-project
+LLVM_COMMIT                := 5177676261147ef6c930e060a13a895e45bb6af4
+LLVM_DEFAULT_TARGET_TRIPLE := riscv32-unknown-elf
+LLVM_TARGETS_TO_BUILD      := RISCV
+LLVM_ENABLE_PROJECTS       := "clang;lld"
+MAKE_BUILD_TYPE            := Release
+
+
+NEWLIB_REPO                := https://sourceware.org/git/newlib-cygwin.git
+NEWLIB_COMMIT              := 761ef3b434b5eb7f321e58c3fae1f578f5c34999
+
+.PHONY: llvm
+llvm: check_env_vars
+	cd $(LLVM_DIR) && mkdir install &&                                     \
+	git clone --recurse-submodules $(LLVM_REPO) && cd llvm-project &&      \
+	git checkout $(LLVM_COMMIT) && rm build/ -r -f &&                      \
+	mkdir build && cd build &&                                             \
+	$(CMAKE) -G "Unix Makefiles"                                           \
+	         -DCMAKE_C_COMPILER=$(CC)                                      \
+	         -DCMAKE_INSTALL_PREFIX=$(LLVM_INSTALL_DIR)                    \
+	         -DLLVM_ENABLE_PROJECTS=$(LLVM_ENABLE_PROJECTS)                \
+	         -DCMAKE_BUILD_TYPE=$(MAKE_BUILD_TYPE)                         \
+	         -DLLVM_DEFAULT_TARGET_TRIPLE=$(LLVM_DEFAULT_TARGET_TRIPLE)    \
+	         -DLLVM_TARGETS_TO_BUILD=$(LLVM_TARGETS_TO_BUILD)              \
+	         ../llvm && cd .. &&                                           \
+	$(CMAKE) --build build --target install && cd $(LLVM_DIR) &&           \
+	git clone $(NEWLIB_REPO) newlib && cd newlib &&                        \
+	git checkout $(NEWLIB_COMMIT) &&                                       \
+	rm -rf build && mkdir -p build && cd build &&                          \
+	../configure --prefix=${LLVM_INSTALL_DIR}                              \
+	--target=riscv32-unknown-elf                                           \
+	CC_FOR_TARGET="${LLVM_INSTALL_DIR}/bin/clang -march=rv32gc -mabi=ilp32 \
+	-mno-relax -mcmodel=medany"                                            \
+	AS_FOR_TARGET=${LLVM_INSTALL_DIR}/bin/llvm-as                          \
+	AR_FOR_TARGET=${LLVM_INSTALL_DIR}/bin/llvm-ar                          \
+	LD_FOR_TARGET=${LLVM_INSTALL_DIR}/bin/llvm-ld                          \
+	RANLIB_FOR_TARGET=${LLVM_INSTALL_DIR}/bin/llvm-ranlib &&               \
+	make &&                                                                \
+	make install
+
+check_env_vars:
+ifndef LLVM_DIR
+	$(error LLVM_DIR variable not set. (set it to the path where the llvm  \
+	repository will be cloned to and the llvm toolchain will be installed))
+endif

--- a/test/Makefile
+++ b/test/Makefile
@@ -18,6 +18,9 @@ CORE_DIR := $(TEST_DIR)/../$(CORE)/
 # select the simulator to use; either verilator (default) or vivado
 SIMULATOR ?= verilator
 
+# select the compiler to use; either gcc (default) or llvm
+COMPILER ?= gcc
+
 # test directories
 TEST_DIRS := lsu alu mul sld elem csr kernel misc
 
@@ -151,7 +154,8 @@ $(TESTS_ALL): %: $$(addsuffix .vmem,$$(basename $$(shell [ -d % ] && ls %/*.S ||
 	prog=$(abspath $(<:%.S=%));                                               \
 	obj="$(abspath $(^:%.S=%.o))";                                            \
 	log="$${prog}_build.log";                                                 \
-	make -f $(TEST_DIR)/../sw/Makefile PROG=$$prog OBJ="$$obj" >$$log 2>&1;   \
+	make -f $(TEST_DIR)/../sw/Makefile PROG=$$prog OBJ="$$obj"                \
+	COMPILER=$(COMPILER) >$$log 2>&1;                                         \
 	if [ "$$?" != "0" ]; then                                                 \
 	    echo "[ ERROR ] $@ build failed; content of $$log:";                  \
 	    cat $$log;                                                            \

--- a/test/README.md
+++ b/test/README.md
@@ -19,6 +19,10 @@ xsim (part of the
 [Xilinx Vivado](https://www.xilinx.com/products/design-tools/vivado.html)
 suite, set `SIMULATOR` to `vivado` to use it) are supported.
 
+The default compiler used for the tests is GCC. This can be changed by
+setting the environment variable `COMPILER`. GCC and LLVM + Clang (set `COMPILER`
+to `llvm` to use it) are supported.
+
 By default tracing is disabled in Verilator.  Use the environment variable
 `TRACE_VCD` to specify a `*.vcd` file path if you wish to generate a VCD trace
 file of a set of tests.  The specified path is relative to the subdirectory of


### PR DESCRIPTION
Hi @michael-platzer

While using LLVM + Clang to compile and run the test programs I updated the Makefiles to have a COMPILER option that can be set to `ggc` (default) or `llvm`. I also added a makefile (toolchain.mk) to compile the llvm toolchain and a linker script (lld_link.ld) that is compatible with the llvm lld linker.

These addition do not fix any existing "problem" but I opened the pull request because I thought it could be useful to support llvm. (llvm supports the zve32x extension and seems to better maintained than the rvv-intrinsics branch of gcc)