### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install verible and lint
         run: |
-          curl -sSL https://api.github.com/repos/chipsalliance/verible/releases/latest | grep browser_download_url | grep Ubuntu-20.04 | cut -d '"' -f 4 | wget -qi -
+          curl -sSL https://api.github.com/repos/chipsalliance/verible/releases/latest | grep browser_download_url | grep Ubuntu-20.04 | grep "x86_64" | cut -d '"' -f 4 | wget -qi -
           mkdir verible
           tar -xf verible*.tar.gz -C verible --strip-components=1
           export PATH=$PATH:$PWD/verible/bin:/opt/verilator/bin

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -10,7 +10,7 @@ jobs:
   verilator:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: cache-verilator
         with:
           path: /opt/verilator
@@ -75,6 +75,16 @@ jobs:
         unit: [lsu, alu, mul, sld, elem, csr, misc]
         main_core: [ibex, cv32e40x]
     steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 8192
+          temp-reserve-mb: 8192
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+
       - uses: actions/checkout@v2
         with:
           submodules: true

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -38,11 +38,11 @@ jobs:
     needs: verilator
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: false
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: cache-verilator
         with:
           path: /opt/verilator
@@ -85,11 +85,11 @@ jobs:
           remove-haskell: 'true'
           remove-codeql: 'true'
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: cache-verilator
         with:
           path: /opt/verilator


### PR DESCRIPTION
- Fixed failing download in lint job
- Increase runner disk space to avoid running out of storage
- Update actions to latest versions

One CI job (`unit (elem, cv32e40x)`) is still failing but AFAIK this was already an issue a year ago:

```
[23702] %Error: vproc_core_sva.svh:22: Assertion failed in TOP.vproc_top.v_core: attempt to commit instruction ID 3, which already had a commit transaction
%Error: /home/runner/work/vicuna/vicuna/sim//../sva//vproc_core_sva.svh:22: Verilog $stop
```